### PR TITLE
Add background processing with traits futures

### DIFF
--- a/stage5.2_fuller_application/pycasa/model/image_folder.py
+++ b/stage5.2_fuller_application/pycasa/model/image_folder.py
@@ -65,7 +65,7 @@ class ImageFolder(HasStrictTraits):
         return pd.DataFrame(data)
 
     def compute_num_faces(self, **kwargs):
-        num_faces = self._compute_num_faces_iter(**kwargs)
+        num_faces = self._compute_num_faces(**kwargs)
         self._update_num_faces_in_df(num_faces)
 
     def compute_num_faces_background(self, **kwargs):

--- a/stage5.2_fuller_application/pycasa/model/image_folder.py
+++ b/stage5.2_fuller_application/pycasa/model/image_folder.py
@@ -86,8 +86,8 @@ class ImageFolder(HasStrictTraits):
             # Yield partial results to future.
             yield i, len(image_file.detect_faces(**kwargs))
 
-    def _update_num_faces_in_df(self, i, num_faces):
-        self.data.at[i, NUM_FACE_COL] = num_faces
+    def _update_num_faces_in_df(self, img_idx, num_faces):
+        self.data.at[img_idx, NUM_FACE_COL] = num_faces
         self.data_updated = True
 
     @observe("future:result_event")

--- a/stage5.2_fuller_application/pycasa/model/image_folder.py
+++ b/stage5.2_fuller_application/pycasa/model/image_folder.py
@@ -71,7 +71,7 @@ class ImageFolder(HasStrictTraits):
     def compute_num_faces_background(self, **kwargs):
         self.future = submit_call(
             self.traits_executor,
-            self._compute_num_faces_iter,
+            self._compute_num_faces,
             **kwargs
         )
 
@@ -91,7 +91,7 @@ class ImageFolder(HasStrictTraits):
 
     @observe("future:done")
     def _update_df(self, event):
-        self._update_num_faces_in_df(event.new)
+        self._update_num_faces_in_df(self.future.result)
 
     def _get_executor_idle(self):
         return self.future is None or self.future.done

--- a/stage5.2_fuller_application/pycasa/model/tests/test_image_folder.py
+++ b/stage5.2_fuller_application/pycasa/model/tests/test_image_folder.py
@@ -4,7 +4,10 @@ from unittest import TestCase
 import numpy as np
 import pandas as pd
 
-from pycasa.model.image_folder import ImageFolder
+from pyface.toolkit import toolkit_object
+from traits_futures.api import TraitsExecutor
+
+from pycasa.model.image_folder import ImageFolder, NUM_FACE_COL
 
 import ets_tutorial
 
@@ -14,8 +17,22 @@ SAMPLE_IMG_DIR = join(TUTORIAL_DIR, "..", "sample_images")
 
 HERE = dirname(__file__)
 
+# Maximum timeout for blocking calls.
+SAFETY_TIMEOUT = 300
 
-class TestImageFolder(TestCase):
+# GuiTestAssistant is only available for Qt.
+GuiTestAssistant = toolkit_object("util.gui_test_assistant:GuiTestAssistant")
+
+
+class TestImageFolder(GuiTestAssistant, TestCase):
+    def setUp(self):
+        GuiTestAssistant.setUp(self)
+        self.traits_executor = TraitsExecutor()
+
+    def tearDown(self):
+        self.traits_executor.shutdown(timeout=SAFETY_TIMEOUT)
+        GuiTestAssistant.tearDown(self)
+
     def test_no_folder(self):
         with self.assertRaises(ValueError):
             ImageFolder()
@@ -36,3 +53,16 @@ class TestImageFolder(TestCase):
         self.assertEqual(len(data), 2)
         for key in ['ExifVersion', 'ExifImageWidth', 'ExifImageHeight']:
             self.assertIn(key, data.columns)
+
+    def test_compute_num_faces_background(self):
+        image_folder = ImageFolder(
+            path=SAMPLE_IMG_DIR,
+            traits_executor=self.traits_executor
+        )
+        image_folder.compute_num_faces_background()
+        self.assertEventuallyTrueInGui(
+            lambda: image_folder.future.done, timeout=SAFETY_TIMEOUT
+        )
+        self.assertEqual(
+            image_folder.data[NUM_FACE_COL].to_list(), [5.0, 3.0]
+        )

--- a/stage5.2_fuller_application/pycasa/ui/image_folder_editor.py
+++ b/stage5.2_fuller_application/pycasa/ui/image_folder_editor.py
@@ -1,5 +1,4 @@
-from traits.api import Property, observe
-from pyface.api import warning
+from traits.api import Property
 from pyface.tasks.api import Editor
 
 from .image_folder_view import ImageFolderView
@@ -35,9 +34,3 @@ class ImageFolderEditor(Editor):
 
     def _get_tooltip(self):
         return self.obj.path
-
-    @observe("closing")
-    def _veto_if_computing(self, event):
-        event.new.veto = not self.obj.executor_idle
-        if event.new.veto:
-            warning(self.control, "Please wait for computation to finish!")

--- a/stage5.2_fuller_application/pycasa/ui/image_folder_editor.py
+++ b/stage5.2_fuller_application/pycasa/ui/image_folder_editor.py
@@ -1,4 +1,5 @@
-from traits.api import Property
+from traits.api import Property, observe
+from pyface.api import warning
 from pyface.tasks.api import Editor
 
 from .image_folder_view import ImageFolderView
@@ -34,3 +35,9 @@ class ImageFolderEditor(Editor):
 
     def _get_tooltip(self):
         return self.obj.path
+
+    @observe("closing")
+    def _veto_if_computing(self, event):
+        event.new.veto = not self.obj.executor_idle
+        if event.new.veto:
+            warning(self.control, "Please wait for computation to finish!")

--- a/stage5.2_fuller_application/pycasa/ui/image_folder_view.py
+++ b/stage5.2_fuller_application/pycasa/ui/image_folder_view.py
@@ -1,7 +1,7 @@
 # General imports
 
 # ETS imports
-from traits.api import Button, Instance, observe
+from traits.api import Bool, Button, Instance, observe
 from traitsui.api import HGroup, Item, Label, ModelView, Spring, View
 from traitsui.ui_editors.data_frame_editor import DataFrameEditor
 # Local imports
@@ -12,6 +12,10 @@ class ImageFolderView(ModelView):
     """ ModelView for an image folder object.
     """
     model = Instance(ImageFolder)
+
+    cancel = Button("Cancel")
+
+    _cancel_clicked = Bool
 
     scan = Button("Scan for faces...")
 
@@ -32,6 +36,11 @@ class ImageFolderView(ModelView):
                 show_label=False,
                 enabled_when="len(model.data) > 0 and model.executor_idle",
             ),
+            Item(
+                "cancel",
+                show_label=False,
+                enabled_when="not model.executor_idle and not _cancel_clicked",
+            ),
             Spring(),
         )
     )
@@ -39,3 +48,13 @@ class ImageFolderView(ModelView):
     @observe("scan")
     def scan_for_faces(self, event):
         self.model.compute_num_faces_background()
+
+    @observe("cancel")
+    def _cancel_scan(self, event):
+        self.model.future.cancel()
+        self._cancel_clicked = True
+
+    @observe("model:future:done")
+    def _reset_click_counter(self, event):
+        if self.model.future.done:
+            self._cancel_clicked = False

--- a/stage5.2_fuller_application/pycasa/ui/image_folder_view.py
+++ b/stage5.2_fuller_application/pycasa/ui/image_folder_view.py
@@ -1,7 +1,7 @@
 # General imports
 
 # ETS imports
-from traits.api import Bool, Button, Instance, observe
+from traits.api import Button, Instance, observe
 from traitsui.api import HGroup, Item, Label, ModelView, Spring, View
 from traitsui.ui_editors.data_frame_editor import DataFrameEditor
 # Local imports
@@ -12,10 +12,6 @@ class ImageFolderView(ModelView):
     """ ModelView for an image folder object.
     """
     model = Instance(ImageFolder)
-
-    cancel = Button("Cancel")
-
-    _cancel_clicked = Bool
 
     scan = Button("Scan for faces...")
 
@@ -36,11 +32,6 @@ class ImageFolderView(ModelView):
                 show_label=False,
                 enabled_when="len(model.data) > 0 and model.executor_idle",
             ),
-            Item(
-                "cancel",
-                show_label=False,
-                enabled_when="not model.executor_idle and not _cancel_clicked",
-            ),
             Spring(),
         )
     )
@@ -48,13 +39,3 @@ class ImageFolderView(ModelView):
     @observe("scan")
     def scan_for_faces(self, event):
         self.model.compute_num_faces_background()
-
-    @observe("cancel")
-    def _cancel_scan(self, event):
-        self.model.future.cancel()
-        self._cancel_clicked = True
-
-    @observe("model:future:done")
-    def _reset_click_counter(self, event):
-        if self.model.future.done:
-            self._cancel_clicked = False

--- a/stage5.2_fuller_application/pycasa/ui/image_folder_view.py
+++ b/stage5.2_fuller_application/pycasa/ui/image_folder_view.py
@@ -27,11 +27,15 @@ class ImageFolderView(ModelView):
         ),
         HGroup(
             Spring(),
-            Item("scan", show_label=False, enabled_when="len(model.data) > 0"),
+            Item(
+                "scan",
+                show_label=False,
+                enabled_when="len(model.data) > 0 and model.executor_idle",
+            ),
             Spring(),
         )
     )
 
     @observe("scan")
     def scan_for_faces(self, event):
-        self.model.compute_num_faces()
+        self.model.compute_num_faces_background()

--- a/stage5.2_fuller_application/pycasa/ui/tasks/pycasa_task.py
+++ b/stage5.2_fuller_application/pycasa/ui/tasks/pycasa_task.py
@@ -3,6 +3,7 @@ from os.path import splitext
 
 # ETS imports
 from traits.api import Instance
+from traits_futures.api import TraitsExecutor
 from pyface.tasks.api import PaneItem, SplitEditorAreaPane, Task, TaskLayout
 
 # Local imports
@@ -14,6 +15,10 @@ from ..image_file_editor import ImageFileEditor
 
 
 class PycasaTask(Task):
+
+    #: An executor for background tasks.
+    traits_executor = Instance(TraitsExecutor, ())
+
     # 'Task' traits -----------------------------------------------------------
 
     #: The unique id of the task.
@@ -52,7 +57,10 @@ class PycasaTask(Task):
             obj = ImageFile(filepath=filepath)
             self.central_pane.edit(obj, factory=ImageFileEditor)
         elif file_ext == "":
-            obj = ImageFolder(path=filepath)
+            obj = ImageFolder(
+                path=filepath,
+                traits_executor=self.traits_executor
+            )
             self.central_pane.edit(obj, factory=ImageFolderEditor)
         else:
             print("Unsupported file format: {}".format(file_ext))

--- a/stage5.2_fuller_application/pycasa/ui/tasks/pycasa_task.py
+++ b/stage5.2_fuller_application/pycasa/ui/tasks/pycasa_task.py
@@ -64,3 +64,7 @@ class PycasaTask(Task):
             self.central_pane.edit(obj, factory=ImageFolderEditor)
         else:
             print("Unsupported file format: {}".format(file_ext))
+
+    def prepare_destroy(self):
+        self.traits_executor.shutdown()
+        return super().prepare_destroy()


### PR DESCRIPTION
Based on feature/add_step_5.2

Closes #10.
Contributes to #29.

Adds background processing with traits futures. Opening early to get feedback. 

After:
![traits_futures](https://user-images.githubusercontent.com/33434221/172264540-3f8090c1-c904-4bbc-941a-d8978e3aad98.gif)

