### PR TITLE
Avoid recreating figure to update it

### DIFF
--- a/ets_tutorial/util/mpl_figure_editor.py
+++ b/ets_tutorial/util/mpl_figure_editor.py
@@ -31,6 +31,13 @@ class _MplFigureEditor(Editor):
         """Creates sub-widgets and does layout.
         """
         canvas = FigureCanvasQTAgg(figure=self.value)
+
+        # Ensure figure gets redrawn if it becomes stale.
+        # Ref: https://matplotlib.org/stable/users/explain/interactive_guide.html#stale-artists  # noqa: 501
+        def stale_callback(artist, val):
+            canvas.draw_idle()
+        self.value.stale_callback = stale_callback
+
         # Allow the figure canvas to expand and shrink with the main widget.
         canvas.setSizePolicy(
             QtGui.QSizePolicy.Policy.Expanding,

--- a/ets_tutorial/util/mpl_figure_editor.py
+++ b/ets_tutorial/util/mpl_figure_editor.py
@@ -2,6 +2,7 @@ import matplotlib
 from matplotlib.backends.backend_qt5agg import (
         FigureCanvasQTAgg, NavigationToolbar2QT
 )
+from matplotlib.backend_bases import FigureCanvasBase
 from pyface.qt import QtGui
 from traitsui.api import BasicEditorFactory
 from traitsui.qt4.editor import Editor
@@ -31,13 +32,6 @@ class _MplFigureEditor(Editor):
         """Creates sub-widgets and does layout.
         """
         canvas = FigureCanvasQTAgg(figure=self.value)
-
-        # Ensure figure gets redrawn if it becomes stale.
-        # Ref: https://matplotlib.org/stable/users/explain/interactive_guide.html#stale-artists  # noqa: 501
-        def stale_callback(artist, val):
-            canvas.draw_idle()
-        self.value.stale_callback = stale_callback
-
         # Allow the figure canvas to expand and shrink with the main widget.
         canvas.setSizePolicy(
             QtGui.QSizePolicy.Policy.Expanding,

--- a/ets_tutorial/util/mpl_figure_editor.py
+++ b/ets_tutorial/util/mpl_figure_editor.py
@@ -2,7 +2,6 @@ import matplotlib
 from matplotlib.backends.backend_qt5agg import (
         FigureCanvasQTAgg, NavigationToolbar2QT
 )
-from matplotlib.backend_bases import FigureCanvasBase
 from pyface.qt import QtGui
 from traitsui.api import BasicEditorFactory
 from traitsui.qt4.editor import Editor

--- a/stage5.2_fuller_application/pycasa/ui/image_file_view.py
+++ b/stage5.2_fuller_application/pycasa/ui/image_file_view.py
@@ -42,12 +42,9 @@ class ImageFileView(ModelView):
 
     @observe("model.faces")
     def update_mpl_figure_with_faces(self, events):
-        figure = Figure()
-        axes = figure.add_subplot(111)
-        axes.imshow(self.model.to_array())
-
+        [axis] = self.figure.get_axes()
         for face in self.model.faces:
-            axes.add_patch(
+            axis.add_patch(
                 patches.Rectangle(
                     (face['c'], face['r']),
                     face['width'],
@@ -57,4 +54,6 @@ class ImageFileView(ModelView):
                     linewidth=2
                 )
             )
-        self.figure = figure
+        # Update the figure.
+        self.figure.canvas.draw_idle()
+        self.figure.canvas.flush_events()


### PR DESCRIPTION
Our hypothesis (in https://github.com/jonathanrocher/ets_tutorial/pull/45#issuecomment-1167609098) was that
> we can set `Figure.stale_callback` to `canvas.draw_idle` and it should Just Work. 

Unfortunately, it didn't. `Figure.stale_callback` is called multiple times and invoking `draw_idle` that often makes the app unresponsive.

This PR manually invokes `draw_idle` to update the figure without recreating it.

