### PR TITLE
Improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Create a new conda environment called `ets_tutorial` and install local
 dependencies with the following commands:
 ```commandline
 conda create -n ets_tutorial python=3.6 pandas matplotlib traits traitsui scikit-image pillow pyqt ipython importlib_resources importlib_metadata
+conda activate ets_tutorial
 python setup.py install
 ```
 Activate the new environment with `conda activate ets_tutorial`.

--- a/README.md
+++ b/README.md
@@ -33,11 +33,20 @@ git clone git@github.com:jonathanrocher/ets_tutorial.git
 
 ### EDM users (recommended)
 First, download and install EDM from https://www.enthought.com/edm/. Then, 
-open a `Terminal`/`Powershell`/`Cmd Prompt`/ and navigate to the folder 
-where the repo was cloned. Enter the following command to create a 
-dedicated Python environment and install all dependencies in it:
+open a `Terminal`/`Powershell`/`Cmd Prompt`/ and create a lighweight bootstrap environment to run the installation commands.
 ```commandline
-python ci build
+edm envs create bootstrap
+edm install --environment bootstrap click
+```
+Next, enter the following commands to create a 
+dedicated Python environment called `ets_tutorial` and install all dependencies in it:
+```commandline
+edm run -e bootstrap -- python ci build --environment ets_tutorial
+```
+All application related `python` commands are assumed to run in this
+environment. You can activate the environment with:
+```commandline
+edm shell -e ets_tutorial
 ```
 
 ### Conda users

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ edm shell -e ets_tutorial
 Create a new conda environment called `ets_tutorial` and install local
 dependencies with the following commands:
 ```commandline
-conda create -n ets_tutorial python=3.6 pandas matplotlib traits traitsui
-scikit-image pillow pyqt ipython importlib_resources importlib_metadata
+conda create -n ets_tutorial python=3.6 pandas matplotlib traits traitsui scikit-image pillow pyqt ipython importlib_resources importlib_metadata
 python setup.py install
 ```
+Activate the new environment with `conda activate ets_tutorial`.
 
 ### pip users
 Assuming a Python environment is created and activated on your machine, for 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,20 @@ edm shell -e ets_tutorial
 ```
 
 ### Conda users
-[TODO]
+Create a new conda environment called `ets_tutorial` and install local
+dependencies with the following commands:
+```commandline
+conda create -n ets_tutorial python=3.6 pandas matplotlib traits traitsui
+scikit-image pillow pyqt ipython importlib_resources importlib_metadata
+python setup.py install
+```
 
 ### pip users
 Assuming a Python environment is created and activated on your machine, for 
 example from https://www.python.org/, 
 ```commandline
 pip install pandas matplotlib traits traitsui scikits-image pillow pyqt5 ipython
+python setup.py install
 ```
 
 ## Getting help


### PR DESCRIPTION
The `python ci build` command needs to be run in a Python environment with `click` installed. Update instructions in readme to reflect that.

Also add instructions for conda and update instructions for pip.