### PR TITLE
Fix key errors in image folder view in Stage 5.3

### DIFF
--- a/stage5.3_fuller_application/pycasa/ui/image_folder_view.py
+++ b/stage5.3_fuller_application/pycasa/ui/image_folder_view.py
@@ -91,7 +91,7 @@ class ImageFolderView(ModelView):
     @observe("scan")
     def scan_for_faces(self, event):
         self.model.compute_num_faces()
-        self.all_data = self.model.data.copy()
+        self.all_data.update(self.model.data)
 
     @observe("selected_years")
     def update_years(self, event):
@@ -117,12 +117,18 @@ class ImageFolderView(ModelView):
         return pd.Series(np.ones(len(self.model.data), dtype=bool))
 
     def _all_data_default(self):
+        # Enrich metadata with missing fields: date time, make
         data = self.model.data.copy()
+
         if DATETIME_COL not in data.columns:
             data[DATETIME_COL] = np.nan
 
         if MAKE_COL not in data.columns:
             data[MAKE_COL] = np.nan
+
+        def parse_year(x):
+            return x.split(":")[0] if isinstance(x, str) else "unknown"
+        data[YEAR_KEY] = data[DATETIME_COL].apply(parse_year)
 
         return data
 
@@ -130,10 +136,6 @@ class ImageFolderView(ModelView):
         return self.all_data
 
     def _all_years_default(self):
-        def parse_year(x):
-            return x.split(":")[0] if isinstance(x, str) else "unknown"
-
-        self.all_data[YEAR_KEY] = self.all_data[DATETIME_COL].apply(parse_year)
         return sorted(self.all_data[YEAR_KEY].unique().tolist())
 
 


### PR DESCRIPTION
To reproduce:
1. Launch the app from Stage 5.3
2. Double click on the `ets_tutorial/ets_tutorial/sample_images` in the browsser pane
3. Click "Scan for faces"
4. App crashes with `KeyError: "Make"`.

That's because computing faces update `all_data` but neglected to add missing columns.