### PR TITLE
Make the `ImageFile` model consistent across all stages

### DIFF
--- a/stage2.1_traited_script/traited_face_detect.py
+++ b/stage2.1_traited_script/traited_face_detect.py
@@ -7,11 +7,15 @@ from skimage import data
 from skimage.feature import Cascade
 import matplotlib.pyplot as plt
 from matplotlib import patches
-from os.path import join
+from os.path import join, splitext
 import numpy as np
 
 # ETS imports
-from traits.api import Dict, File, HasStrictTraits, List, observe
+from traits.api import (
+    Array, cached_property, Dict, File, HasStrictTraits, List, Property
+)
+
+SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg"]
 
 
 class ImageFile(HasStrictTraits):
@@ -19,21 +23,34 @@ class ImageFile(HasStrictTraits):
     """
     filepath = File
 
+    metadata = Property(Dict, depends_on="filepath")
+
+    data = Property(Array, depends_on="filepath")
+
     faces = List
 
-    metadata = Dict
+    def _is_valid_file(self):
+        return (
+            bool(self.filepath) and
+            splitext(self.filepath)[1].lower() in SUPPORTED_FORMATS
+        )
 
-    def to_array(self):
+    @cached_property
+    def _get_data(self):
+        if not self._is_valid_file():
+            return np.array([])
         with PIL.Image.open(self.filepath) as img:
             return np.asarray(img)
 
-    @observe("filepath")
-    def update_metadata(self, event):
-
+    @cached_property
+    def _get_metadata(self):
+        if not self._is_valid_file():
+            return {}
         with PIL.Image.open(self.filepath) as img:
             exif = img._getexif()
-        self.metadata = {TAGS[k]: v for k, v in exif.items()
-                         if k in TAGS}
+        if not exif:
+            return {}
+        return {TAGS[k]: v for k, v in exif.items() if k in TAGS}
 
     def detect_faces(self):
         # Load the trained file from the module root.
@@ -42,14 +59,13 @@ class ImageFile(HasStrictTraits):
         # Initialize the detector cascade.
         detector = Cascade(trained_file)
 
-        detected = detector.detect_multi_scale(img=self.to_array(),
+        detected = detector.detect_multi_scale(img=self.data,
                                                scale_factor=1.2,
                                                step_ratio=1,
                                                min_size=(60, 60),
                                                max_size=(600, 600))
         self.faces = detected
-
-        self.metadata["Number of faces detected"] = len(detected)
+        return self.faces
 
 
 if __name__ == "__main__":
@@ -72,7 +88,7 @@ if __name__ == "__main__":
 
         # Visualize results ---------------------------------------------------
 
-        plt.imshow(img.to_array())
+        plt.imshow(img.data)
         img_desc = plt.gca()
         plt.set_cmap('gray')
 

--- a/stage2.1_traited_script/traited_face_detect.py
+++ b/stage2.1_traited_script/traited_face_detect.py
@@ -15,7 +15,7 @@ from traits.api import (
     Array, cached_property, Dict, File, HasStrictTraits, List, Property
 )
 
-SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg"]
+SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg", ".PNG", ".JPG", ".JPEG"]
 
 
 class ImageFile(HasStrictTraits):

--- a/stage3.0_first_views/test_traited_face_detect.py
+++ b/stage3.0_first_views/test_traited_face_detect.py
@@ -17,21 +17,19 @@ class TestImageFile(TestCase):
     def test_no_image_file(self):
         img = ImageFile()
         self.assertEqual(img.metadata, {})
-        data = img.to_array()
-        self.assertIsInstance(data, np.ndarray)
-        self.assertEqual(data.shape, (0,))
+        self.assertIsInstance(img.data, np.ndarray)
+        self.assertEqual(img.data.shape, (0,))
 
     def test_image_metadata(self):
         img = ImageFile(filepath=SAMPLE_IMG1)
         self.assertNotEqual(img.metadata, {})
         for key in ['ExifVersion', 'ExifImageWidth', 'ExifImageHeight']:
             self.assertIn(key, img.metadata.keys())
-        data = img.to_array()
         expected_shape = (img.metadata['ExifImageHeight'],
                           img.metadata['ExifImageWidth'], 3)
-        self.assertEqual(data.shape, expected_shape)
+        self.assertEqual(img.data.shape, expected_shape)
 
     def test_detects_faces(self):
         img = ImageFile(filepath=SAMPLE_IMG1)
+        img.detect_faces()
         self.assertEqual(len(img.faces), 5)
-        self.assertEqual(img.metadata["Number of faces"], 5)

--- a/stage3.0_first_views/traited_face_detect.py
+++ b/stage3.0_first_views/traited_face_detect.py
@@ -15,7 +15,7 @@ from traits.api import (
 )
 from traitsui.api import Item, OKButton, View
 
-SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg"]
+SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg", ".PNG", ".JPG", ".JPEG"]
 
 
 class ImageFile(HasStrictTraits):

--- a/stage3.0_first_views/traited_face_detect.py
+++ b/stage3.0_first_views/traited_face_detect.py
@@ -1,4 +1,5 @@
 # General imports
+from os.path import splitext
 import PIL.Image
 import matplotlib.pyplot as plt
 import numpy as np
@@ -9,13 +10,12 @@ from skimage.feature import Cascade
 
 # ETS imports
 from traits.api import (
-    Dict,
-    File,
-    HasStrictTraits,
-    List,
-    observe,
+    Array, cached_property, Dict, File, HasStrictTraits, List,
+    Property
 )
 from traitsui.api import Item, OKButton, View
+
+SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg"]
 
 
 class ImageFile(HasStrictTraits):
@@ -23,9 +23,11 @@ class ImageFile(HasStrictTraits):
     """
     filepath = File
 
-    faces = List
+    metadata = Property(Dict, depends_on="filepath")
 
-    metadata = Dict
+    data = Property(Array, depends_on="filepath")
+
+    faces = List
 
     traits_view = View(
         Item(name='filepath', show_label=False),
@@ -34,58 +36,52 @@ class ImageFile(HasStrictTraits):
         width=640
     )
 
-    def to_array(self):
-        if not self.filepath:
-            return np.array([])
+    def _is_valid_file(self):
+        return (
+            bool(self.filepath) and
+            splitext(self.filepath)[1].lower() in SUPPORTED_FORMATS
+        )
 
+    @cached_property
+    def _get_data(self):
+        if not self._is_valid_file():
+            return np.array([])
         with PIL.Image.open(self.filepath) as img:
             return np.asarray(img)
 
-    @observe("filepath")
-    def _update_faces_and_metadata(self, event):
-        self.metadata = {}
-        self._update_metadata_with_exif()
-        self._detect_faces()
-        print(self.metadata)
-        print(f"Number of faces: {self.metadata['Number of faces']}")
-
-    def _update_metadata_with_exif(self):
-        if not self.filepath:
-            return
+    @cached_property
+    def _get_metadata(self):
+        if not self._is_valid_file():
+            return {}
         with PIL.Image.open(self.filepath) as img:
             exif = img._getexif()
         if not exif:
-            return
-        self.metadata.update(
-            {TAGS[k]: v for k, v in exif.items() if k in TAGS}
-        )
+            return {}
+        return {TAGS[k]: v for k, v in exif.items() if k in TAGS}
 
-    def _detect_faces(self):
-        self.faces = []
-        if not self.filepath:
-            return
+    def detect_faces(self):
         # Load the trained file from the module root.
         trained_file = data.lbp_frontal_face_cascade_filename()
+
         # Initialize the detector cascade.
         detector = Cascade(trained_file)
-        faces = detector.detect_multi_scale(
-            img=self.to_array(),
-            scale_factor=1.2,
-            step_ratio=1,
-            min_size=(60, 60),
-            max_size=(600, 600)
-        )
-        self.faces.extend(faces)
-        self.metadata['Number of faces'] = len(self.faces)
+
+        detected = detector.detect_multi_scale(img=self.data,
+                                               scale_factor=1.2,
+                                               step_ratio=1,
+                                               min_size=(60, 60),
+                                               max_size=(600, 600))
+        self.faces = detected
+        return self.faces
 
 
 if __name__ == '__main__':
     img = ImageFile()
     img.configure_traits()
 
-    plt.imshow(img.to_array())
+    plt.imshow(img.data)
     img_desc = plt.gca()
-    for patch in img.faces:
+    for patch in img.detect_faces():
         img_desc.add_patch(
             patches.Rectangle(
                 (patch['c'], patch['r']),

--- a/stage3.1_first_views/test_traited_face_detect.py
+++ b/stage3.1_first_views/test_traited_face_detect.py
@@ -19,24 +19,22 @@ class TestImageFile(TestCase):
     def test_no_image_file(self):
         img = ImageFile()
         self.assertEqual(img.metadata, {})
-        data = img.to_array()
-        self.assertIsInstance(data, np.ndarray)
-        self.assertEqual(data.shape, (0,))
+        self.assertIsInstance(img.data, np.ndarray)
+        self.assertEqual(img.data.shape, (0,))
 
     def test_image_metadata(self):
         img = ImageFile(filepath=SAMPLE_IMG1)
         self.assertNotEqual(img.metadata, {})
         for key in ['ExifVersion', 'ExifImageWidth', 'ExifImageHeight']:
             self.assertIn(key, img.metadata.keys())
-        data = img.to_array()
         expected_shape = (img.metadata['ExifImageHeight'],
                           img.metadata['ExifImageWidth'], 3)
-        self.assertEqual(data.shape, expected_shape)
+        self.assertEqual(img.data.shape, expected_shape)
 
     def test_detects_faces(self):
         img = ImageFile(filepath=SAMPLE_IMG1)
+        img.detect_faces()
         self.assertEqual(len(img.faces), 5)
-        self.assertEqual(img.metadata["Number of faces"], 5)
 
 
 class TestImageFileView(TestCase):

--- a/stage3.1_first_views/traited_face_detect.py
+++ b/stage3.1_first_views/traited_face_detect.py
@@ -18,7 +18,7 @@ from traitsui.api import Item, ModelView, OKButton, View
 # Local imports
 from ets_tutorial.util.mpl_figure_editor import MplFigureEditor
 
-SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg"]
+SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg", ".PNG", ".JPG", ".JPEG"]
 
 
 class ImageFile(HasStrictTraits):

--- a/stage3.1_first_views/traited_face_detect.py
+++ b/stage3.1_first_views/traited_face_detect.py
@@ -1,4 +1,5 @@
 # General imports
+from os.path import splitext
 import PIL.Image
 import numpy as np
 from matplotlib import patches
@@ -9,17 +10,15 @@ from skimage.feature import Cascade
 
 # ETS imports
 from traits.api import (
-    Dict,
-    File,
-    HasStrictTraits,
-    Instance,
-    List,
-    observe,
+    Array, cached_property, Dict, File, HasStrictTraits, Instance, List,
+    observe, Property
 )
 from traitsui.api import Item, ModelView, OKButton, View
 
 # Local imports
 from ets_tutorial.util.mpl_figure_editor import MplFigureEditor
+
+SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg"]
 
 
 class ImageFile(HasStrictTraits):
@@ -27,52 +26,49 @@ class ImageFile(HasStrictTraits):
     """
     filepath = File
 
+    metadata = Property(Dict, depends_on="filepath")
+
+    data = Property(Array, depends_on="filepath")
+
     faces = List
 
-    metadata = Dict
+    def _is_valid_file(self):
+        return (
+            bool(self.filepath) and
+            splitext(self.filepath)[1].lower() in SUPPORTED_FORMATS
+        )
 
-    def to_array(self):
-        if not self.filepath:
+    @cached_property
+    def _get_data(self):
+        if not self._is_valid_file():
             return np.array([])
-
         with PIL.Image.open(self.filepath) as img:
             return np.asarray(img)
 
-    @observe("filepath")
-    def _update_faces_and_metadata(self, event):
-        self.metadata = {}
-        self._update_metadata_with_exif()
-        self._detect_faces()
-        print(self.metadata)
-
-    def _update_metadata_with_exif(self):
-        if not self.filepath:
-            return
+    @cached_property
+    def _get_metadata(self):
+        if not self._is_valid_file():
+            return {}
         with PIL.Image.open(self.filepath) as img:
             exif = img._getexif()
         if not exif:
-            return
-        self.metadata.update(
-            {TAGS[k]: v for k, v in exif.items() if k in TAGS}
-        )
+            return {}
+        return {TAGS[k]: v for k, v in exif.items() if k in TAGS}
 
-    def _detect_faces(self):
-        self.faces = []
-        if not self.filepath:
-            return
+    def detect_faces(self):
         # Load the trained file from the module root.
         trained_file = data.lbp_frontal_face_cascade_filename()
+
         # Initialize the detector cascade.
         detector = Cascade(trained_file)
-        faces = detector.detect_multi_scale(
-            img=self.to_array(),
-            scale_factor=1.2,
-            step_ratio=1,
-            min_size=(60, 60),
-            max_size=(600, 600)
-        )
-        self.faces.extend(faces)
-        self.metadata['Number of faces'] = len(self.faces)
+
+        detected = detector.detect_multi_scale(img=self.data,
+                                               scale_factor=1.2,
+                                               step_ratio=1,
+                                               min_size=(60, 60),
+                                               max_size=(600, 600))
+        self.faces = detected
+        return self.faces
 
 
 class ImageFileView(ModelView):
@@ -96,8 +92,8 @@ class ImageFileView(ModelView):
             return
         figure = Figure()
         axes = figure.add_subplot(111)
-        axes.imshow(self.model.to_array())
-        for patch in self.model.faces:
+        axes.imshow(self.model.data)
+        for patch in self.model.detect_faces():
             axes.add_patch(
                 patches.Rectangle(
                     (patch['c'], patch['r']),

--- a/stage4.1_first_application/pycasa/model/image_file.py
+++ b/stage4.1_first_application/pycasa/model/image_file.py
@@ -1,10 +1,17 @@
 # General imports
+from os.path import splitext
 import PIL.Image
 from PIL.ExifTags import TAGS
+from skimage import data
+from skimage.feature import Cascade
 import numpy as np
 
 # ETS imports
-from traits.api import cached_property, Dict, File, HasStrictTraits, Property
+from traits.api import (
+    Array, cached_property, Dict, File, HasStrictTraits, List, Property
+)
+
+SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg"]
 
 
 class ImageFile(HasStrictTraits):
@@ -14,23 +21,44 @@ class ImageFile(HasStrictTraits):
 
     metadata = Property(Dict, depends_on="filepath")
 
-    def to_array(self):
-        if not self.filepath:
-            return np.array([])
+    data = Property(Array, depends_on="filepath")
 
+    faces = List
+
+    def _is_valid_file(self):
+        return (
+            bool(self.filepath) and
+            splitext(self.filepath)[1].lower() in SUPPORTED_FORMATS
+        )
+
+    @cached_property
+    def _get_data(self):
+        if not self._is_valid_file():
+            return np.array([])
         with PIL.Image.open(self.filepath) as img:
             return np.asarray(img)
 
     @cached_property
     def _get_metadata(self):
-        if not self.filepath:
+        if not self._is_valid_file():
             return {}
-
         with PIL.Image.open(self.filepath) as img:
             exif = img._getexif()
-
-        if exif:
-            return {TAGS[k]: v for k, v in exif.items()
-                    if k in TAGS}
-        else:
+        if not exif:
             return {}
+        return {TAGS[k]: v for k, v in exif.items() if k in TAGS}
+
+    def detect_faces(self):
+        # Load the trained file from the module root.
+        trained_file = data.lbp_frontal_face_cascade_filename()
+
+        # Initialize the detector cascade.
+        detector = Cascade(trained_file)
+
+        detected = detector.detect_multi_scale(img=self.data,
+                                               scale_factor=1.2,
+                                               step_ratio=1,
+                                               min_size=(60, 60),
+                                               max_size=(600, 600))
+        self.faces = detected
+        return self.faces

--- a/stage4.1_first_application/pycasa/model/image_file.py
+++ b/stage4.1_first_application/pycasa/model/image_file.py
@@ -11,7 +11,7 @@ from traits.api import (
     Array, cached_property, Dict, File, HasStrictTraits, List, Property
 )
 
-SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg"]
+SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg", ".PNG", ".JPG", ".JPEG"]
 
 
 class ImageFile(HasStrictTraits):

--- a/stage4.1_first_application/pycasa/model/test_image_file.py
+++ b/stage4.1_first_application/pycasa/model/test_image_file.py
@@ -18,16 +18,14 @@ class TestImageFile(TestCase):
     def test_no_image_file(self):
         img = ImageFile()
         self.assertEqual(img.metadata, {})
-        data = img.to_array()
-        self.assertIsInstance(data, np.ndarray)
-        self.assertEqual(data.shape, (0,))
+        self.assertIsInstance(img.data, np.ndarray)
+        self.assertEqual(img.data.shape, (0,))
 
     def test_image_metadata(self):
         img = ImageFile(filepath=SAMPLE_IMG1)
         self.assertNotEqual(img.metadata, {})
         for key in ['ExifVersion', 'ExifImageWidth', 'ExifImageHeight']:
             self.assertIn(key, img.metadata.keys())
-        data = img.to_array()
         expected_shape = (img.metadata['ExifImageHeight'],
                           img.metadata['ExifImageWidth'], 3)
-        self.assertEqual(data.shape, expected_shape)
+        self.assertEqual(img.data.shape, expected_shape)

--- a/stage4.1_first_application/pycasa/ui/image_file_view.py
+++ b/stage4.1_first_application/pycasa/ui/image_file_view.py
@@ -26,5 +26,5 @@ class ImageFileView(ModelView):
     def build_mpl_figure(self, event):
         figure = Figure()
         axes = figure.add_subplot(111)
-        axes.imshow(self.model.to_array())
+        axes.imshow(self.model.data)
         self.figure = figure

--- a/stage4.1_first_application/pycasa/ui/tasks/pycasa_task.py
+++ b/stage4.1_first_application/pycasa/ui/tasks/pycasa_task.py
@@ -7,10 +7,8 @@ from pyface.tasks.api import PaneItem, SplitEditorAreaPane, Task, TaskLayout
 
 # Local imports
 from .pycasa_browser_pane import PycasaBrowserPane
-from ...model.image_file import ImageFile
+from ...model.image_file import ImageFile, SUPPORTED_FORMATS
 from ..image_file_editor import ImageFileEditor
-
-SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg"]
 
 
 class PycasaTask(Task):
@@ -52,4 +50,4 @@ class PycasaTask(Task):
             obj = ImageFile(filepath=filepath)
             self.central_pane.edit(obj, factory=ImageFileEditor)
         else:
-            print("Unsupported file format: {}".format(file_ext))
+            print("Unsupported file format: '{}'".format(file_ext))

--- a/stage5.1_fuller_application/README.md
+++ b/stage5.1_fuller_application/README.md
@@ -1,3 +1,3 @@
 # Second real version of the pycasa ETS pyface application!
-Building on the application state 4.2, this version simply adds an editor and a 
-view for a folder to be visualized.
+Building on the application state 4.1, this version adds a model and view for
+a folder of image files.

--- a/stage5.1_fuller_application/pycasa/model/image_file.py
+++ b/stage5.1_fuller_application/pycasa/model/image_file.py
@@ -1,11 +1,15 @@
 # General imports
-import os
+from os.path import splitext
 import PIL.Image
 from PIL.ExifTags import TAGS
+from skimage import data
+from skimage.feature import Cascade
 import numpy as np
 
 # ETS imports
-from traits.api import cached_property, Dict, File, HasStrictTraits, Property
+from traits.api import (
+    Array, cached_property, Dict, File, HasStrictTraits, List, Property
+)
 
 SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg"]
 
@@ -17,25 +21,44 @@ class ImageFile(HasStrictTraits):
 
     metadata = Property(Dict, depends_on="filepath")
 
-    def to_array(self):
-        file_ext = os.path.splitext(self.filepath)[1].lower()
-        if not self.filepath or file_ext not in SUPPORTED_FORMATS:
-            return np.array([])
+    data = Property(Array, depends_on="filepath")
 
+    faces = List
+
+    def _is_valid_file(self):
+        return (
+            bool(self.filepath) and
+            splitext(self.filepath)[1].lower() in SUPPORTED_FORMATS
+        )
+
+    @cached_property
+    def _get_data(self):
+        if not self._is_valid_file():
+            return np.array([])
         with PIL.Image.open(self.filepath) as img:
             return np.asarray(img)
 
     @cached_property
     def _get_metadata(self):
-        file_ext = os.path.splitext(self.filepath)[1].lower()
-        if not self.filepath or file_ext not in SUPPORTED_FORMATS:
+        if not self._is_valid_file():
             return {}
-
         with PIL.Image.open(self.filepath) as img:
             exif = img._getexif()
-
-        if exif:
-            return {TAGS[k]: v for k, v in exif.items()
-                    if k in TAGS}
-        else:
+        if not exif:
             return {}
+        return {TAGS[k]: v for k, v in exif.items() if k in TAGS}
+
+    def detect_faces(self):
+        # Load the trained file from the module root.
+        trained_file = data.lbp_frontal_face_cascade_filename()
+
+        # Initialize the detector cascade.
+        detector = Cascade(trained_file)
+
+        detected = detector.detect_multi_scale(img=self.data,
+                                               scale_factor=1.2,
+                                               step_ratio=1,
+                                               min_size=(60, 60),
+                                               max_size=(600, 600))
+        self.faces = detected
+        return self.faces

--- a/stage5.1_fuller_application/pycasa/model/image_file.py
+++ b/stage5.1_fuller_application/pycasa/model/image_file.py
@@ -11,7 +11,7 @@ from traits.api import (
     Array, cached_property, Dict, File, HasStrictTraits, List, Property
 )
 
-SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg"]
+SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg", ".PNG", ".JPG", ".JPEG"]
 
 
 class ImageFile(HasStrictTraits):

--- a/stage5.1_fuller_application/pycasa/model/tests/test_image_file.py
+++ b/stage5.1_fuller_application/pycasa/model/tests/test_image_file.py
@@ -18,23 +18,20 @@ class TestImageFile(TestCase):
     def test_no_image_file(self):
         img = ImageFile()
         self.assertEqual(img.metadata, {})
-        data = img.to_array()
-        self.assertIsInstance(data, np.ndarray)
-        self.assertEqual(data.shape, (0,))
+        self.assertIsInstance(img.data, np.ndarray)
+        self.assertEqual(img.data.shape, (0,))
 
     def test_bad_type_image_file(self):
         img = ImageFile(filepath=__file__)
         self.assertEqual(img.metadata, {})
-        data = img.to_array()
-        self.assertIsInstance(data, np.ndarray)
-        self.assertEqual(data.shape, (0,))
+        self.assertIsInstance(img.data, np.ndarray)
+        self.assertEqual(img.data.shape, (0,))
 
     def test_image_metadata(self):
         img = ImageFile(filepath=SAMPLE_IMG1)
         self.assertNotEqual(img.metadata, {})
         for key in ['ExifVersion', 'ExifImageWidth', 'ExifImageHeight']:
             self.assertIn(key, img.metadata.keys())
-        data = img.to_array()
         expected_shape = (img.metadata['ExifImageHeight'],
                           img.metadata['ExifImageWidth'], 3)
-        self.assertEqual(data.shape, expected_shape)
+        self.assertEqual(img.data.shape, expected_shape)

--- a/stage5.1_fuller_application/pycasa/model/tests/test_image_folder.py
+++ b/stage5.1_fuller_application/pycasa/model/tests/test_image_folder.py
@@ -1,7 +1,7 @@
 from os.path import dirname, join, split
 import unittest
 
-from pycasa.model.image_folder import ImageFolder
+from pycasa.model.image_folder import FILENAME_COL, ImageFolder
 
 import ets_tutorial
 
@@ -24,8 +24,8 @@ class TestImageFolder(unittest.TestCase):
             set(self.filenames)
         )
 
-    def test_create_metadata_df(self):
-        df = self.img_folder.create_metadata_df()
-        self.assertEqual(set(df.index), set(self.filenames))
+    def test_data_correct(self):
+        df = self.img_folder.data
+        self.assertEqual(set(df[FILENAME_COL]), set(self.filenames))
         self.assertIn("ExifVersion", df)
         self.assertIn("ApertureValue", df)

--- a/stage5.1_fuller_application/pycasa/ui/image_file_view.py
+++ b/stage5.1_fuller_application/pycasa/ui/image_file_view.py
@@ -26,5 +26,5 @@ class ImageFileView(ModelView):
     def build_mpl_figure(self, event):
         figure = Figure()
         axes = figure.add_subplot(111)
-        axes.imshow(self.model.to_array())
+        axes.imshow(self.model.data)
         self.figure = figure

--- a/stage5.1_fuller_application/pycasa/ui/image_folder_view.py
+++ b/stage5.1_fuller_application/pycasa/ui/image_folder_view.py
@@ -1,12 +1,18 @@
-from traits.api import cached_property, Instance, Property
-from traitsui.api import Item, ModelView, View
+from traits.api import Instance
+from traitsui.api import (
+    HGroup, Item, Label, ModelView, Spring, View
+)
 from traitsui.ui_editors.data_frame_editor import DataFrameEditor
 
-from pycasa.model.image_folder import ImageFolder
+# Local imports
+from pycasa.model.image_folder import FILENAME_COL, ImageFolder, NUM_FACE_COL
 
-DISPLAYED_COLUMNS = [
+
+DISPLAYED_COLUMNS = [FILENAME_COL, NUM_FACE_COL] + [
     'ApertureValue', 'ExifVersion', 'Model', 'Make', 'LensModel', 'DateTime',
-    'ShutterSpeedValue', 'XResolution', 'YResolution'
+    'ShutterSpeedValue', 'ExposureTime', 'XResolution', 'YResolution',
+    'Orientation', 'GPSInfo', 'DigitalZoomRatio', 'FocalLengthIn35mmFilm',
+    'ISOSpeedRatings', 'SceneType'
 ]
 
 
@@ -15,22 +21,22 @@ class ImageFolderView(ModelView):
     """
     model = Instance(ImageFolder)
 
-    metadata_df = Property(depends_on="model.images.items")
-
     view = View(
         Item('model.directory', style="readonly", show_label=False),
         Item(
-            'metadata_df',
+            'model.data',
             editor=DataFrameEditor(columns=DISPLAYED_COLUMNS),
             show_label=False,
-            width=1200,
+            visible_when="len(model.data) > 0",
+        ),
+        HGroup(
+            Spring(),
+            Label("No images found. No data to show"),
+            Spring(),
+            visible_when="len(model.data) == 0",
         ),
         resizable=True
     )
-
-    @cached_property
-    def _get_metadata_df(self):
-        return self.model.create_metadata_df()
 
 
 if __name__ == '__main__':

--- a/stage5.1_fuller_application/pycasa/ui/tests/test_image_folder_view.py
+++ b/stage5.1_fuller_application/pycasa/ui/tests/test_image_folder_view.py
@@ -17,5 +17,5 @@ class TestImageFolderView(unittest.TestCase):
         view = ImageFolderView(model=ImageFolder(directory=SAMPLE_IMG_DIR))
         tester = UITester()
         with tester.create_ui(view) as ui:
-            df = tester.find_by_name(ui, "metadata_df")
+            df = tester.find_by_name(ui, "data")
             df.inspect(IsVisible())

--- a/stage5.2_fuller_application/pycasa/model/image_file.py
+++ b/stage5.2_fuller_application/pycasa/model/image_file.py
@@ -11,7 +11,7 @@ from traits.api import (
     Array, cached_property, Dict, File, HasStrictTraits, List, Property
 )
 
-SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg"]
+SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg", ".PNG", ".JPG", ".JPEG"]
 
 
 class ImageFile(HasStrictTraits):

--- a/stage5.2_fuller_application/pycasa/model/image_file.py
+++ b/stage5.2_fuller_application/pycasa/model/image_file.py
@@ -1,5 +1,5 @@
 # General imports
-import os
+from os.path import splitext
 import PIL.Image
 from PIL.ExifTags import TAGS
 from skimage import data
@@ -7,8 +7,9 @@ from skimage.feature import Cascade
 import numpy as np
 
 # ETS imports
-from traits.api import Array, cached_property, Dict, File, HasStrictTraits, \
-    List, Property
+from traits.api import (
+    Array, cached_property, Dict, File, HasStrictTraits, List, Property
+)
 
 SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg"]
 
@@ -24,43 +25,40 @@ class ImageFile(HasStrictTraits):
 
     faces = List
 
-    def to_array(self):
-        file_ext = os.path.splitext(self.filepath)[1].lower()
-        if not self.filepath or file_ext not in SUPPORTED_FORMATS:
-            return np.array([])
+    def _is_valid_file(self):
+        return (
+            bool(self.filepath) and
+            splitext(self.filepath)[1].lower() in SUPPORTED_FORMATS
+        )
 
+    @cached_property
+    def _get_data(self):
+        if not self._is_valid_file():
+            return np.array([])
         with PIL.Image.open(self.filepath) as img:
             return np.asarray(img)
 
     @cached_property
-    def _get_data(self):
-        return self.to_array()
-
-    @cached_property
     def _get_metadata(self):
-        file_ext = os.path.splitext(self.filepath)[1].lower()
-        if not self.filepath or file_ext not in SUPPORTED_FORMATS:
+        if not self._is_valid_file():
             return {}
-
         with PIL.Image.open(self.filepath) as img:
             exif = img._getexif()
-
-        if exif:
-            return {TAGS[k]: v for k, v in exif.items()
-                    if k in TAGS}
-        else:
+        if not exif:
             return {}
+        return {TAGS[k]: v for k, v in exif.items() if k in TAGS}
 
-    def detect_faces(self, scale_factor=1.2, step_ratio=1, min_size=60,
-                     max_size=600):
-        """ Detect faces in the image.
-        """
+    def detect_faces(self):
+        # Load the trained file from the module root.
         trained_file = data.lbp_frontal_face_cascade_filename()
+
+        # Initialize the detector cascade.
         detector = Cascade(trained_file)
-        faces = detector.detect_multi_scale(img=self.data,
-                                            scale_factor=scale_factor,
-                                            step_ratio=step_ratio,
-                                            min_size=(min_size, min_size),
-                                            max_size=(max_size, max_size))
-        self.faces = faces
-        return faces
+
+        detected = detector.detect_multi_scale(img=self.data,
+                                               scale_factor=1.2,
+                                               step_ratio=1,
+                                               min_size=(60, 60),
+                                               max_size=(600, 600))
+        self.faces = detected
+        return self.faces

--- a/stage5.2_fuller_application/pycasa/model/tests/test_image_file.py
+++ b/stage5.2_fuller_application/pycasa/model/tests/test_image_file.py
@@ -18,31 +18,28 @@ class TestImageFile(TestCase):
     def test_no_image_file(self):
         img = ImageFile()
         self.assertEqual(img.metadata, {})
-        data = img.to_array()
-        self.assertIsInstance(data, np.ndarray)
-        self.assertEqual(data.shape, (0,))
+        self.assertIsInstance(img.data, np.ndarray)
+        self.assertEqual(img.data.shape, (0,))
 
     def test_bad_type_image_file(self):
         img = ImageFile(filepath=__file__)
         self.assertEqual(img.metadata, {})
-        data = img.to_array()
-        self.assertIsInstance(data, np.ndarray)
-        self.assertEqual(data.shape, (0,))
+        self.assertIsInstance(img.data, np.ndarray)
+        self.assertEqual(img.data.shape, (0,))
 
     def test_image_metadata(self):
         img = ImageFile(filepath=SAMPLE_IMG1)
         self.assertNotEqual(img.metadata, {})
         for key in ['ExifVersion', 'ExifImageWidth', 'ExifImageHeight']:
             self.assertIn(key, img.metadata.keys())
-        data = img.to_array()
         expected_shape = (img.metadata['ExifImageHeight'],
                           img.metadata['ExifImageWidth'], 3)
-        self.assertEqual(data.shape, expected_shape)
+        self.assertEqual(img.data.shape, expected_shape)
 
     def test_image_data(self):
         img = ImageFile(filepath=SAMPLE_IMG1)
         self.assertNotIn(0, img.data.shape)
-        np.testing.assert_almost_equal(img.data, img.to_array())
+        np.testing.assert_almost_equal(img.data, img.data)
         self.assertIsInstance(img.data, np.ndarray)
         self.assertNotEqual(img.data.mean(), 0)
 

--- a/stage5.2_fuller_application/pycasa/model/tests/test_image_folder.py
+++ b/stage5.2_fuller_application/pycasa/model/tests/test_image_folder.py
@@ -17,21 +17,19 @@ HERE = dirname(__file__)
 class TestImageFolder(TestCase):
     def test_no_folder(self):
         with self.assertRaises(ValueError):
-            ImageFolder()
+            ImageFolder(directory="path/to/nonexistent/dir")
 
     def test_with_file(self):
         with self.assertRaises(ValueError):
-            ImageFolder(path=__file__)
+            ImageFolder(directory=__file__)
 
     def test_empty_folder(self):
-        img = ImageFolder(path=HERE)
-        data = img.to_dataframe()
-        self.assertIsInstance(data, pd.DataFrame)
-        self.assertEqual(len(data), 0)
+        img_folder = ImageFolder(directory=HERE)
+        self.assertIsInstance(img_folder.data, pd.DataFrame)
+        self.assertEqual(len(img_folder.data), 0)
 
     def test_real_folder(self):
-        img = ImageFolder(path=SAMPLE_IMG_DIR)
-        data = img.to_dataframe()
-        self.assertEqual(len(data), 2)
+        img_folder = ImageFolder(directory=SAMPLE_IMG_DIR)
+        self.assertEqual(len(img_folder.data), 2)
         for key in ['ExifVersion', 'ExifImageWidth', 'ExifImageHeight']:
-            self.assertIn(key, data.columns)
+            self.assertIn(key, img_folder.data.columns)

--- a/stage5.2_fuller_application/pycasa/ui/image_file_view.py
+++ b/stage5.2_fuller_application/pycasa/ui/image_file_view.py
@@ -37,7 +37,8 @@ class ImageFileView(ModelView):
         axes.imshow(self.model.data)
         self.figure = figure
 
-    def _detect_button_fired(self):
+    @observe("detect_button")
+    def _detect_button_fired(self, event):
         self.model.detect_faces()
 
     @observe("model.faces")

--- a/stage5.2_fuller_application/pycasa/ui/image_file_view.py
+++ b/stage5.2_fuller_application/pycasa/ui/image_file_view.py
@@ -34,7 +34,7 @@ class ImageFileView(ModelView):
     def build_mpl_figure(self, event):
         figure = Figure()
         axes = figure.add_subplot(111)
-        axes.imshow(self.model.to_array())
+        axes.imshow(self.model.data)
         self.figure = figure
 
     def _detect_button_fired(self):
@@ -44,7 +44,7 @@ class ImageFileView(ModelView):
     def update_mpl_figure_with_faces(self, events):
         figure = Figure()
         axes = figure.add_subplot(111)
-        axes.imshow(self.model.to_array())
+        axes.imshow(self.model.data)
 
         for face in self.model.faces:
             axes.add_patch(

--- a/stage5.2_fuller_application/pycasa/ui/image_folder_editor.py
+++ b/stage5.2_fuller_application/pycasa/ui/image_folder_editor.py
@@ -30,7 +30,7 @@ class ImageFolderEditor(Editor):
     # -------------------------------------------------------------------------
 
     def _get_name(self):
-        return self.obj.path[:25]
+        return self.obj.directory[:25]
 
     def _get_tooltip(self):
-        return self.obj.path
+        return self.obj.directory

--- a/stage5.2_fuller_application/pycasa/ui/image_folder_view.py
+++ b/stage5.2_fuller_application/pycasa/ui/image_folder_view.py
@@ -4,8 +4,17 @@
 from traits.api import Button, Instance, observe
 from traitsui.api import HGroup, Item, Label, ModelView, Spring, View
 from traitsui.ui_editors.data_frame_editor import DataFrameEditor
+
 # Local imports
-from ..model.image_folder import ImageFolder
+from pycasa.model.image_folder import FILENAME_COL, ImageFolder, NUM_FACE_COL
+
+
+DISPLAYED_COLUMNS = [FILENAME_COL, NUM_FACE_COL] + [
+    'ApertureValue', 'ExifVersion', 'Model', 'Make', 'LensModel', 'DateTime',
+    'ShutterSpeedValue', 'ExposureTime', 'XResolution', 'YResolution',
+    'Orientation', 'GPSInfo', 'DigitalZoomRatio', 'FocalLengthIn35mmFilm',
+    'ISOSpeedRatings', 'SceneType'
+]
 
 
 class ImageFolderView(ModelView):
@@ -16,9 +25,13 @@ class ImageFolderView(ModelView):
     scan = Button("Scan for faces...")
 
     view = View(
-        Item("model.path", style="readonly", show_label=False),
-        Item("model.data", editor=DataFrameEditor(update="data_updated"),
-             show_label=False, visible_when="len(model.data) > 0"),
+        Item("model.directory", style="readonly", show_label=False),
+        Item(
+            "model.data",
+            editor=DataFrameEditor(columns=DISPLAYED_COLUMNS,
+                                   update="data_updated"),
+            show_label=False,
+            visible_when="len(model.data) > 0"),
         HGroup(
             Spring(),
             Label("No images found. No data to show"),

--- a/stage5.2_fuller_application/pycasa/ui/tasks/pycasa_task.py
+++ b/stage5.2_fuller_application/pycasa/ui/tasks/pycasa_task.py
@@ -52,7 +52,7 @@ class PycasaTask(Task):
             obj = ImageFile(filepath=filepath)
             self.central_pane.edit(obj, factory=ImageFileEditor)
         elif file_ext == "":
-            obj = ImageFolder(path=filepath)
+            obj = ImageFolder(directory=filepath)
             self.central_pane.edit(obj, factory=ImageFolderEditor)
         else:
             print("Unsupported file format: {}".format(file_ext))

--- a/stage5.3_fuller_application/README.md
+++ b/stage5.3_fuller_application/README.md
@@ -1,3 +1,3 @@
 # Second real version of the pycasa ETS pyface application
-Building on the application state 5.1, this version adds a button to the folder 
-and file views so the faces can be detected.
+Building on the application state 5.2, this version adds a controls to filter
+the data displayed for an image folder.

--- a/stage5.3_fuller_application/pycasa/model/image_file.py
+++ b/stage5.3_fuller_application/pycasa/model/image_file.py
@@ -11,7 +11,7 @@ from traits.api import (
     Array, cached_property, Dict, File, HasStrictTraits, List, Property
 )
 
-SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg"]
+SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg", ".PNG", ".JPG", ".JPEG"]
 
 
 class ImageFile(HasStrictTraits):

--- a/stage5.3_fuller_application/pycasa/model/image_file.py
+++ b/stage5.3_fuller_application/pycasa/model/image_file.py
@@ -1,5 +1,5 @@
 # General imports
-import os
+from os.path import splitext
 import PIL.Image
 from PIL.ExifTags import TAGS
 from skimage import data
@@ -7,8 +7,9 @@ from skimage.feature import Cascade
 import numpy as np
 
 # ETS imports
-from traits.api import Array, cached_property, Dict, File, HasStrictTraits, \
-    List, Property
+from traits.api import (
+    Array, cached_property, Dict, File, HasStrictTraits, List, Property
+)
 
 SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg"]
 
@@ -24,43 +25,40 @@ class ImageFile(HasStrictTraits):
 
     faces = List
 
-    def to_array(self):
-        file_ext = os.path.splitext(self.filepath)[1].lower()
-        if not self.filepath or file_ext not in SUPPORTED_FORMATS:
-            return np.array([])
+    def _is_valid_file(self):
+        return (
+            bool(self.filepath) and
+            splitext(self.filepath)[1].lower() in SUPPORTED_FORMATS
+        )
 
+    @cached_property
+    def _get_data(self):
+        if not self._is_valid_file():
+            return np.array([])
         with PIL.Image.open(self.filepath) as img:
             return np.asarray(img)
 
     @cached_property
-    def _get_data(self):
-        return self.to_array()
-
-    @cached_property
     def _get_metadata(self):
-        file_ext = os.path.splitext(self.filepath)[1].lower()
-        if not self.filepath or file_ext not in SUPPORTED_FORMATS:
+        if not self._is_valid_file():
             return {}
-
         with PIL.Image.open(self.filepath) as img:
             exif = img._getexif()
-
-        if exif:
-            return {TAGS[k]: v for k, v in exif.items()
-                    if k in TAGS}
-        else:
+        if not exif:
             return {}
+        return {TAGS[k]: v for k, v in exif.items() if k in TAGS}
 
-    def detect_faces(self, scale_factor=1.2, step_ratio=1, min_size=60,
-                     max_size=600):
-        """ Detect faces in the image.
-        """
+    def detect_faces(self):
+        # Load the trained file from the module root.
         trained_file = data.lbp_frontal_face_cascade_filename()
+
+        # Initialize the detector cascade.
         detector = Cascade(trained_file)
-        faces = detector.detect_multi_scale(img=self.data,
-                                            scale_factor=scale_factor,
-                                            step_ratio=step_ratio,
-                                            min_size=(min_size, min_size),
-                                            max_size=(max_size, max_size))
-        self.faces = faces
-        return faces
+
+        detected = detector.detect_multi_scale(img=self.data,
+                                               scale_factor=1.2,
+                                               step_ratio=1,
+                                               min_size=(60, 60),
+                                               max_size=(600, 600))
+        self.faces = detected
+        return self.faces

--- a/stage5.3_fuller_application/pycasa/model/tests/test_image_file.py
+++ b/stage5.3_fuller_application/pycasa/model/tests/test_image_file.py
@@ -18,31 +18,28 @@ class TestImageFile(TestCase):
     def test_no_image_file(self):
         img = ImageFile()
         self.assertEqual(img.metadata, {})
-        data = img.to_array()
-        self.assertIsInstance(data, np.ndarray)
-        self.assertEqual(data.shape, (0,))
+        self.assertIsInstance(img.data, np.ndarray)
+        self.assertEqual(img.data.shape, (0,))
 
     def test_bad_type_image_file(self):
         img = ImageFile(filepath=__file__)
         self.assertEqual(img.metadata, {})
-        data = img.to_array()
-        self.assertIsInstance(data, np.ndarray)
-        self.assertEqual(data.shape, (0,))
+        self.assertIsInstance(img.data, np.ndarray)
+        self.assertEqual(img.data.shape, (0,))
 
     def test_image_metadata(self):
         img = ImageFile(filepath=SAMPLE_IMG1)
         self.assertNotEqual(img.metadata, {})
         for key in ['ExifVersion', 'ExifImageWidth', 'ExifImageHeight']:
             self.assertIn(key, img.metadata.keys())
-        data = img.to_array()
         expected_shape = (img.metadata['ExifImageHeight'],
                           img.metadata['ExifImageWidth'], 3)
-        self.assertEqual(data.shape, expected_shape)
+        self.assertEqual(img.data.shape, expected_shape)
 
     def test_image_data(self):
         img = ImageFile(filepath=SAMPLE_IMG1)
         self.assertNotIn(0, img.data.shape)
-        np.testing.assert_almost_equal(img.data, img.to_array())
+        np.testing.assert_almost_equal(img.data, img.data)
         self.assertIsInstance(img.data, np.ndarray)
         self.assertNotEqual(img.data.mean(), 0)
 

--- a/stage5.3_fuller_application/pycasa/model/tests/test_image_folder.py
+++ b/stage5.3_fuller_application/pycasa/model/tests/test_image_folder.py
@@ -17,21 +17,19 @@ HERE = dirname(__file__)
 class TestImageFolder(TestCase):
     def test_no_folder(self):
         with self.assertRaises(ValueError):
-            ImageFolder()
+            ImageFolder(directory="path/to/nonexistent/dir")
 
     def test_with_file(self):
         with self.assertRaises(ValueError):
-            ImageFolder(path=__file__)
+            ImageFolder(directory=__file__)
 
     def test_empty_folder(self):
-        img = ImageFolder(path=HERE)
-        data = img.to_dataframe()
-        self.assertIsInstance(data, pd.DataFrame)
-        self.assertEqual(len(data), 0)
+        img_folder = ImageFolder(directory=HERE)
+        self.assertIsInstance(img_folder.data, pd.DataFrame)
+        self.assertEqual(len(img_folder.data), 0)
 
     def test_real_folder(self):
-        img = ImageFolder(path=SAMPLE_IMG_DIR)
-        data = img.to_dataframe()
-        self.assertEqual(len(data), 2)
+        img_folder = ImageFolder(directory=SAMPLE_IMG_DIR)
+        self.assertEqual(len(img_folder.data), 2)
         for key in ['ExifVersion', 'ExifImageWidth', 'ExifImageHeight']:
-            self.assertIn(key, data.columns)
+            self.assertIn(key, img_folder.data.columns)

--- a/stage5.3_fuller_application/pycasa/ui/image_file_view.py
+++ b/stage5.3_fuller_application/pycasa/ui/image_file_view.py
@@ -37,7 +37,8 @@ class ImageFileView(ModelView):
         axes.imshow(self.model.data)
         self.figure = figure
 
-    def _detect_button_fired(self):
+    @observe("detect_button")
+    def _detect_button_fired(self, event):
         self.model.detect_faces()
 
     @observe("model.faces")

--- a/stage5.3_fuller_application/pycasa/ui/image_file_view.py
+++ b/stage5.3_fuller_application/pycasa/ui/image_file_view.py
@@ -34,7 +34,7 @@ class ImageFileView(ModelView):
     def build_mpl_figure(self, event):
         figure = Figure()
         axes = figure.add_subplot(111)
-        axes.imshow(self.model.to_array())
+        axes.imshow(self.model.data)
         self.figure = figure
 
     def _detect_button_fired(self):
@@ -44,7 +44,7 @@ class ImageFileView(ModelView):
     def update_mpl_figure_with_faces(self, events):
         figure = Figure()
         axes = figure.add_subplot(111)
-        axes.imshow(self.model.to_array())
+        axes.imshow(self.model.data)
 
         for face in self.model.faces:
             axes.add_patch(

--- a/stage5.3_fuller_application/pycasa/ui/image_folder_editor.py
+++ b/stage5.3_fuller_application/pycasa/ui/image_folder_editor.py
@@ -30,7 +30,7 @@ class ImageFolderEditor(Editor):
     # -------------------------------------------------------------------------
 
     def _get_name(self):
-        return self.obj.path[:25]
+        return self.obj.directory[:25]
 
     def _get_tooltip(self):
-        return self.obj.path
+        return self.obj.directory

--- a/stage5.3_fuller_application/pycasa/ui/image_folder_view.py
+++ b/stage5.3_fuller_application/pycasa/ui/image_folder_view.py
@@ -9,7 +9,7 @@ from traitsui.api import HGroup, Item, Label, ListStrEditor, ModelView, \
 from traitsui.ui_editors.data_frame_editor import DataFrameEditor
 
 # Local imports
-from ..model.image_folder import FILENAME_COL, ImageFolder, NUM_FACE_COL
+from pycasa.model.image_folder import FILENAME_COL, ImageFolder, NUM_FACE_COL
 
 
 DISPLAYED_COLUMNS = [FILENAME_COL, NUM_FACE_COL] + [
@@ -54,7 +54,7 @@ class ImageFolderView(ModelView):
 
     def traits_view(self):
         view = View(
-            Item("model.path", style="readonly", show_label=False),
+            Item("model.directory", style="readonly", show_label=False),
             HGroup(
                 Spring(),
                 Item("view_filter_controls"),

--- a/stage5.3_fuller_application/pycasa/ui/tasks/pycasa_task.py
+++ b/stage5.3_fuller_application/pycasa/ui/tasks/pycasa_task.py
@@ -52,7 +52,7 @@ class PycasaTask(Task):
             obj = ImageFile(filepath=filepath)
             self.central_pane.edit(obj, factory=ImageFileEditor)
         elif file_ext == "":
-            obj = ImageFolder(path=filepath)
+            obj = ImageFolder(directory=filepath)
             self.central_pane.edit(obj, factory=ImageFolderEditor)
         else:
             print("Unsupported file format: {}".format(file_ext))


### PR DESCRIPTION
Contributes to #51 

The `ImageFile` model doesn't change across stages. It can be finalized early in the tutorial.